### PR TITLE
fix: serviceBackground and dialogIcon

### DIFF
--- a/src/frappe/android
+++ b/src/frappe/android
@@ -316,6 +316,7 @@ chat_sentErrorIcon: #303446
 chat_serviceIcon: #303446
 chat_serviceLink: #303446
 chat_serviceText: #303446
+chat_serviceBackground: #babbf1
 chat_shareBackground: #73799466
 chat_shareBackgroundSelected: #73799499
 chat_status: #a6d189
@@ -418,7 +419,7 @@ dialogFloatingButton: #8caaee
 dialogFloatingButtonPressed: #8caaee
 dialogFloatingIcon: #303446
 dialogGrayLine: #737994
-dialogIcon: #303446
+dialogIcon: #c6d0f5
 dialogInputField: #a5adce
 dialogInputFieldActivated: #8caaee
 dialogLineProgress: #8caaee

--- a/src/latte/android
+++ b/src/latte/android
@@ -315,6 +315,7 @@ chat_sentErrorIcon: #eff1f5
 chat_serviceIcon: #eff1f5
 chat_serviceLink: #eff1f5
 chat_serviceText: #eff1f5
+chat_serviceBackground: #7287fd
 chat_shareBackground: #9ca0b066
 chat_shareBackgroundSelected: #9ca0b099
 chat_status: #40a02b
@@ -417,7 +418,7 @@ dialogFloatingButton: #1e66f5
 dialogFloatingButtonPressed: #1e66f5
 dialogFloatingIcon: #eff1f5
 dialogGrayLine: #9ca0b0
-dialogIcon: #eff1f5
+dialogIcon: #4c4f69
 dialogInputField: #6c6f85
 dialogInputFieldActivated: #1e66f5
 dialogLineProgress: #1e66f5

--- a/src/macchiato/android
+++ b/src/macchiato/android
@@ -316,6 +316,7 @@ chat_sentErrorIcon: #24273a
 chat_serviceIcon: #24273a
 chat_serviceLink: #24273a
 chat_serviceText: #24273a
+chat_serviceBackground: #b7bdf8
 chat_shareBackground: #6e738d66
 chat_shareBackgroundSelected: #6e738d99
 chat_status: #a6da95
@@ -418,7 +419,7 @@ dialogFloatingButton: #8aadf4
 dialogFloatingButtonPressed: #8aadf4
 dialogFloatingIcon: #24273a
 dialogGrayLine: #6e738d
-dialogIcon: #24273a
+dialogIcon: #cad3f5
 dialogInputField: #a5adcb
 dialogInputFieldActivated: #8aadf4
 dialogLineProgress: #8aadf4

--- a/src/mocha/android
+++ b/src/mocha/android
@@ -316,6 +316,7 @@ chat_sentErrorIcon: #1e1e2e
 chat_serviceIcon: #1e1e2e
 chat_serviceLink: #1e1e2e
 chat_serviceText: #1e1e2e
+chat_serviceBackground: #b4befe
 chat_shareBackground: #6c708666
 chat_shareBackgroundSelected: #6c708699
 chat_status: #a6e3a1
@@ -418,7 +419,7 @@ dialogFloatingButton: #89b4fa
 dialogFloatingButtonPressed: #89b4fa
 dialogFloatingIcon: #1e1e2e
 dialogGrayLine: #6c7086
-dialogIcon: #1e1e2e
+dialogIcon: #cdd6f4
 dialogInputField: #a6adc8
 dialogInputFieldActivated: #89b4fa
 dialogLineProgress: #89b4fa


### PR DESCRIPTION
serviceBackground colors date pill. dialogIcon colors icon in dialog popup (such as in theme selector)

Note: This PR only addresses issue in Mocha variant. I haven't checked Latte variant. I have checked both Frappe and Macchiato and although both missing the `chat_serviceBackground` variable, the date pill seems correctly colored.

Preview: 
![Screenshot_20230427-092422_Fork Client](https://user-images.githubusercontent.com/57625126/234750441-a15d3bed-0f83-48ef-b6ad-eef6f4d44bb2.png)
![Screenshot_20230427-100139_Fork Client](https://user-images.githubusercontent.com/57625126/234748944-dd6a93ec-13cd-4668-90f7-f1d72dea0544.png)

